### PR TITLE
Simplify clap code

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -60,16 +60,16 @@ checksum = "14c189c53d098945499cdfa7ecc63567cf3886b3332b312a5b4585d8d3a6a610"
 
 [[package]]
 name = "clap"
-version = "3.1.16"
+version = "3.2.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f52d4f8e4a1419219935762e32913b4430f37cb0c0200ad17a89ee18c0188a9f"
+checksum = "29e724a68d9319343bb3328c9cc2dfde263f4b3142ee1059a9980580171c954b"
 dependencies = [
  "atty",
  "bitflags",
  "clap_derive",
  "clap_lex",
  "indexmap",
- "lazy_static",
+ "once_cell",
  "strsim",
  "termcolor",
  "textwrap",
@@ -77,9 +77,9 @@ dependencies = [
 
 [[package]]
 name = "clap_derive"
-version = "3.1.7"
+version = "3.2.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a3aab4734e083b809aaf5794e14e756d1c798d2c69c7f7de7a09a2f5214993c1"
+checksum = "13547f7012c01ab4a0e8f8967730ada8f9fdf419e8b6c792788f39cf4e46eefa"
 dependencies = [
  "heck",
  "proc-macro-error",
@@ -90,9 +90,9 @@ dependencies = [
 
 [[package]]
 name = "clap_lex"
-version = "0.2.0"
+version = "0.2.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a37c35f1112dad5e6e0b1adaff798507497a18fceeb30cceb3bae7d1427b9213"
+checksum = "2850f2f5a82cbf437dd5af4d49848fbdfc27c157c3d010345776f952765261c5"
 dependencies = [
  "os_str_bytes",
 ]
@@ -159,12 +159,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "lazy_static"
-version = "1.4.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e2abad23fbc42b3700f2f279844dc832adb2b2eb069b2df918f455c4e18cc646"
-
-[[package]]
 name = "libc"
 version = "0.2.124"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -175,6 +169,12 @@ name = "maplit"
 version = "1.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3e2e65a1a2e43cfcb47a895c4c8b10d1f4a61097f9f254f183aee60cad9c651d"
+
+[[package]]
+name = "once_cell"
+version = "1.13.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "074864da206b4973b84eb91683020dbefd6a8c3f0f38e054d93954e891935e4e"
 
 [[package]]
 name = "opaque-debug"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -7,7 +7,7 @@ edition = "2021"
 
 [dependencies]
 roxmltree = "0.14.1"
-clap = { version = "3.1.16", features = ["derive"] }
+clap = { version = "3.2", features = ["derive"] }
 glob = "0.3.0"
 pest = "2.1.3"
 pest_derive = "2.1.0"

--- a/src/main.rs
+++ b/src/main.rs
@@ -8,16 +8,25 @@ use unstruct::config::{parse, LEVEL};
 use std::fs::{File, read_to_string};
 use std::io::Write;
 
+/// Unstruct is a program that parses simple xml files into text files,
+/// suitable for bulk inserts into a relational database
 #[derive(Parser, Debug)]
-#[clap(author, version, about, long_about = "Unstruct is a program that parses simple xml files into text files, suitable for bulk inserts into a relational database.")]
+#[clap(author, version)]
 struct Args {
-    #[clap(short, long, help = "The name of the input xml file or matching files if wildcards are used")]
+    /// The name of the input xml file or matching files if wildcards are used
+    #[clap(short, long)]
     filename: String,
-    #[clap(short, long, help = "The name of the text file into which the results of the parsing will be output")]
+
+    /// The name of the text file into which the results of the parsing will be output
+    #[clap(short, long)]
     outfile: String,
-    #[clap(short, long, help = "The configuration file specifying the parsing rules", default_value="unstruct.parser")]
+
+    /// The configuration file specifying the parsing rules
+    #[clap(short, long, default_value = "unstruct.parser")]
     parser: String,
-    #[clap(short, long, help = "If specified the program will not output any text")]
+
+    /// Do not write any info to output
+    #[clap(short, long)]
     quiet: bool,
 }
 
@@ -185,11 +194,12 @@ fn record(
 }
 
 fn main() {
-    let args = Args::parse();
-    let filename = args.filename;
-    let outfile = args.outfile;
-    let parser = args.parser;
-    let quiet = args.quiet;
+    let Args {
+        filename,
+        outfile,
+        parser,
+        quiet,
+    } = Args::parse();
 
     // read the config containing the mapping between elements and columns
     let configuration = read_to_string(parser);


### PR DESCRIPTION
This makes the clap portion of the code a bit more readable. I also removed the `about` autogenerate since it reads the description from Cargo.toml, and there's none currently.